### PR TITLE
switch from mallinfo to mallinfo2 for updated glibc on fedora 35

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,10 +267,10 @@ FI_LINK_IFELSE([for fdopendir()], [HAVE_FDOPENDIR],
 				 ]])],
 	       [Define to 1 if your system has fdopendir().])
 
-FI_LINK_IFELSE([for mallinfo()], [HAVE_MALLINFO],
+FI_LINK_IFELSE([for mallinfo2()], [HAVE_MALLINFO2],
 	       [AC_LANG_PROGRAM([[#include <malloc.h>]],
-				[[mallinfo();]])],
-	       [Define to 1 if your system has mallinfo().])
+				[[mallinfo2();]])],
+	       [Define to 1 if your system has mallinfo2().])
 
 if test "x$getdents" != "xnot-found"
 then

--- a/utils.c
+++ b/utils.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if HAVE_MALLINFO
+#if HAVE_MALLINFO2
 #  include <malloc.h>
 #endif
 
@@ -84,9 +84,9 @@ setprogname(const char *argvname)
 void
 pmem(void)
 {
-#if HAVE_MALLINFO
-  struct mallinfo minfo;
-  minfo = mallinfo();
+#if HAVE_MALLINFO2
+  struct mallinfo2 minfo;
+  minfo = mallinfo2();
   fprintf(stderr,
 	  "  brk memory = %7ld bytes (%ld top bytes unreleased)\n"
 	  " mmap memory = %7ld bytes\n"


### PR DESCRIPTION
program fails to compile on Fedora 35. A quick google search shows that this is a minimal change to make it compile.